### PR TITLE
Links to the Command service page

### DIFF
--- a/web/Views/Editors/Callback.aspx
+++ b/web/Views/Editors/Callback.aspx
@@ -76,7 +76,7 @@
                     Defines the type of initiator when the <a href="<%= Url.Action("save") %>#forcesave">force saving</a> request is performed.
                     Can have the following values:
                     <ul>
-                        <li><b>0</b> - the force saving request is performed to the <a href="<%= Url.Action("command") %>">command service</a>,</li>
+                        <li><b>0</b> - the force saving request is performed to the <a href="<%= Url.Action("command/forcesave") %>">command service</a>,</li>
                         <li><b>1</b> - the force saving request is performed each time the saving is done (e.g. the <b>Save</b> button is clicked), which is only available when the <a href="<%= Url.Action("config/editor/customization") %>#forcesave">forcesave</a> option is set to <em>true</em>.</li>
                         <li><b>2</b> - the force saving request is performed by timer with the settings from the server config.</li>
                         <%--<li><b>3</b> - the force saving request is performed each time the form is submitted (e.g. the <a href="<%= Url.Action("config/editor/customization") %>#submitForm">Submit form</a> button is clicked).</li>--%>
@@ -129,7 +129,7 @@
             </tr>
             <tr class="tablerow">
                 <td id="userdata" class="copy-link">userdata</td>
-                <td>Defines the custom information sent to the <a href="<%= Url.Action("command") %>#userdata">command service</a> in case it was present in the request.</td>
+                <td>Defines the custom information sent to the <a href="<%= Url.Action("command/forcesave") %>">command service</a> in case it was present in the request.</td>
                 <td>string</td>
                 <td>optional</td>
             </tr>
@@ -201,7 +201,7 @@
 }
 </pre>
 
-    <div id="status-6" class="header-gray copy-link">Sample of JSON object sent to the "callbackUrl" address by document editing service after the <a href="<%= Url.Action("command") %>">forcesave</a> command had been received</div>
+    <div id="status-6" class="header-gray copy-link">Sample of JSON object sent to the "callbackUrl" address by document editing service after the <a href="<%= Url.Action("command/forcesave") %>">forcesave</a> command had been received</div>
     <pre>
 {
     "changesurl": "https://documentserver/url-to-changes.zip",

--- a/web/Views/Editors/Changelog.aspx
+++ b/web/Views/Editors/Changelog.aspx
@@ -18,7 +18,7 @@
     <p class="dscr">The list of changes of ONLYOFFICE Document Server API.</p>
     <h2 id="63" class="copy-link">Version 6.3</h2>
     <ul>
-        <li>Added the <a href="<%= Url.Action("command") %>#c">license</a> command.</li>
+        <li>Added the <a href="<%= Url.Action("command/license") %>">license</a> command.</li>
         <li>Added the <a href="<%= Url.Action("config/editor/customization") %>#hideRulers">editorConfig.customization.hideRulers</a> field.</li>
         <%--<li>Added the <a href="<%= Url.Action("config/editor/customization") %>#submitForm">editorConfig.customization.submitForm</a> field.</li>--%>
         <%--<li>Added a new <a href="<%= Url.Action("callback") %>#used-callbackUrl">forcesavetype</a> (<em>forcesavetype = 3</em>).</li>--%>
@@ -149,7 +149,7 @@
         <li>Added the <a href="<%= Url.Action("config/events") %>#onRequestRestore">events.onRequestRestore</a> event.</li>
         <li>Added the <a href="<%= Url.Action("config/document/permissions") %>#rename">document.permissions.rename</a> field.</li>
         <li>Added the <a href="<%= Url.Action("config/events") %>#onRequestRename">events.onRequestRename</a> event.</li>
-        <li>Added the <a href="<%= Url.Action("command") %>#meta">meta</a> command.</li>
+        <li>Added the <a href="<%= Url.Action("command/meta") %>">meta</a> command.</li>
         <li>Added the <a href="<%= Url.Action("config/events") %>#onMetaChange">events.onMetaChange</a> event.</li>
         <li>Changed the use of <em>callbackUrl</em> from the <a href="<%= Url.Action("callback") %>#used-callbackUrl">last user</a> who joined the co-editing.</li>
         <li>Added the <a href="<%= Url.Action("config/editor") %>#location">editorConfig.location</a> field.</li>
@@ -177,7 +177,7 @@
         <li>Changed the <a href="<%= Url.Action("methods") %>#setHistoryData">setHistoryData</a> method.</li>
         <li>Added the possibility to convert files to <a href="<%= Url.Action("conversionapi") %>#sample-thumbnail">thumbnail</a> in the <a href="<%= Url.Action("conversionapi") %>">document conversion service</a>.</li>
         <li>The POST requests are now used for the interaction with the <a href="<%= Url.Action("command") %>">document command service</a> and the <a href="<%= Url.Action("conversionapi") %>">document conversion service</a>.</li>
-        <li>Added the <a href="<%= Url.Action("command") %>#version">version</a> command.</li>
+        <li>Added the <a href="<%= Url.Action("command/version") %>">version</a> command.</li>
         <li>Added the <a href="<%= Url.Action("signature/") %>">signature</a> for the editor opening and for the incoming and outgoing requests.</li>
     </ul>
 

--- a/web/Views/Editors/Config/Events.ascx
+++ b/web/Views/Editors/Config/Events.ascx
@@ -13,12 +13,12 @@
         <li><a href="#onCollaborativeChanges">onCollaborativeChanges</a> - the document is co-edited by the other user in the <em>strict</em> co-editing mode.</li>
         <li><a href="#onDocumentReady">onDocumentReady</a> - the document is loaded into the document editor.</li>
         <li><a href="#onDocumentStateChange">onDocumentStateChange</a> - the document is modified.</li>
-        <li><a href="#onDownloadAs">onDownloadAs</a> - the absolute URL to the edited file when the <a href="<%= Url.Action("methods") %>#downloadAs">downloadAs</a> method is being called.</li>
+        <li><a href="#onDownloadAs">onDownloadAs</a> - the absolute URL to the edited file when the <em>downloadAs</em> method is being called.</li>
         <li><a href="#onError">onError</a> - an error or some other specific event occurs.</li>
         <li><a href="#onInfo">onInfo</a> - the application opened the file.</li>
-        <li><a href="#onMetaChange">onMetaChange</a> - the meta information of the document is changed via the <a href="<%= Url.Action("command") %>#meta">meta</a> command.</li>
+        <li><a href="#onMetaChange">onMetaChange</a> - the meta information of the document is changed via the <em>meta</em> command.</li>
         <li><a href="#onMakeActionLink">onMakeActionLink</a> - the user is trying to get link for opening the document which contains a bookmark, scrolling to the bookmark position.</li>
-        <li><a href="#onOutdatedVersion">onOutdatedVersion</a> - the document is opened for editing with the old <a href="<%= Url.Action("config/document") %>#key">document.key</a> value, which was used to edit the previous document version and was successfully saved.</li>
+        <li><a href="#onOutdatedVersion">onOutdatedVersion</a> - the document is opened for editing with the old <em>document.key</em> value, which was used to edit the previous document version and was successfully saved.</li>
         <li><a href="#onReady">onReady</a> - the application is loaded into the browser.</li>
         <li><a href="#onRequestClose">onRequestClose</a> - the work with the editor must be ended and the editor must be closed.</li>
         <li><a href="#onRequestCompareFile">onRequestCompareFile</a> - the user is trying to select document for comparing by clicking the <em>Document from Storage</em> button.</li>
@@ -186,7 +186,7 @@ var docEditor = new DocsAPI.DocEditor("placeholder", {
 
     <li>
         <p>
-            <b id="onMetaChange" class="copy-link">onMetaChange</b> - the function called when the meta information of the document is changed via the <a href="<%= Url.Action("command") %>#meta">meta</a> command.
+            <b id="onMetaChange" class="copy-link">onMetaChange</b> - the function called when the meta information of the document is changed via the <a href="<%= Url.Action("command/meta") %>">meta</a> command.
             The name of the document is sent in the <em>data.title</em> parameter.
             The <em>Favorite</em> icon highlighting state is sent in the <em>data.favorite</em> parameter.
             When the user clicks the <em>Favorite</em> icon, the <a href="<%= Url.Action("methods") %>#setFavorite">setFavorite</a> method is called to update the <a href="<%= Url.Action("config/document/info") %>#favorite">information</a> about the <em>Favorite</em> icon highlighting state.

--- a/web/Views/Editors/FAQ/Coediting.ascx
+++ b/web/Views/Editors/FAQ/Coediting.ascx
@@ -17,7 +17,7 @@
 <dl class="faq_block" id="coediting_2">
     <dt>How to find the information about users who are currently editing the document?</dt>
     <dd>
-        <p>You can use the API to send a POST request to the <b>document command service</b>. Use the <em>c</em> parameter for that with the <b>info</b> value and the <em>key</em> parameter identifying the document you want to find the information about. The parameters are sent as a part of the JSON object in the request body:</p>
+        <p>You can use the API to send a POST request to the <b>document command service</b>. Use the <em>c</em> parameter for that with the <a href="<%= Url.Action("command/info") %>">info</a> value and the <em>key</em> parameter identifying the document you want to find the information about. The parameters are sent as a part of the JSON object in the request body:</p>
         <pre>{
     "c": "info",
     "key": "Khirz6zTPdfd7"
@@ -39,7 +39,7 @@
 <dl class="faq_block" id="coediting_3">
     <dt>How to disconnect users who are currently editing the document before saving the document?</dt>
     <dd>
-        <p>To force disconnecting the users from the document before it can be saved, use the API to send a POST request to the <b>document command service</b>. Use the <em>c</em> parameter for that with the <b>drop</b> value and the <em>key</em> parameter identifying the document and the array of the IDs of the users you want to disconnect. The parameters are sent as a part of the JSON object in the request body:</p>
+        <p>To force disconnecting the users from the document before it can be saved, use the API to send a POST request to the <b>document command service</b>. Use the <em>c</em> parameter for that with the <a href="<%= Url.Action("command/drop") %>">drop</a> value and the <em>key</em> parameter identifying the document and the array of the IDs of the users you want to disconnect. The parameters are sent as a part of the JSON object in the request body:</p>
         <pre>{
     "c": "drop",
     "key": "Khirz6zTPdfd7",

--- a/web/Views/Editors/FAQ/General.ascx
+++ b/web/Views/Editors/FAQ/General.ascx
@@ -19,7 +19,7 @@
     <dt>How to find out the current version number of Document Server?</dt>
     <dd>
         <p>The current Document Server version number can be found at the <b>About</b> page of the Document, Presentation or Spreadsheet Editor, right below the logo and the editor name.</p>
-        <p>You can use the API to send a POST request to the <b><b>document command service</b></b>. Use the <em>c</em> parameter for that with the <b>version</b> value, which is sent as a JSON object in the request body:</p>
+        <p>You can use the API to send a POST request to the <b><b>document command service</b></b>. Use the <em>c</em> parameter for that with the <a href="<%= Url.Action("command/version") %>">version</a> value, which is sent as a JSON object in the request body:</p>
         <pre>{
     "c": "version"
 }

--- a/web/Views/Editors/FAQ/Renaming.ascx
+++ b/web/Views/Editors/FAQ/Renaming.ascx
@@ -15,7 +15,7 @@
 <dl class="faq_block" id="renaming_2">
     <dt>How to update the name of the document for all collaborative editors?</dt>
     <dd>
-        <p>To do that the <a href="<%= Url.Action("command") %>#meta">meta</a> option is available. The request must be sent to the <a href="<%= Url.Action("command") %>">document command service</a>, using the <em>meta</em> value for the <em>c</em> parameter:</p>
+        <p>To do that the <a href="<%= Url.Action("command/meta") %>">meta</a> option is available. The request must be sent to the <a href="<%= Url.Action("command") %>">document command service</a>, using the <em>meta</em> value for the <em>c</em> parameter:</p>
         <pre>
 {
     "c": "meta",

--- a/web/Views/Editors/FAQ/Saving.ascx
+++ b/web/Views/Editors/FAQ/Saving.ascx
@@ -12,7 +12,7 @@
         <p>Normally the final document version is compiled once all the users editing it close the document and the delay time (about 10 seconds) passes. But this behavior can be overriden. To do that the <b>forcesave</b> option is available.</p>
         <p>There are several ways to initiate forced saving:</p>
         <ul>
-            <li>Sending the request to the <a href="<%= Url.Action("command") %>">document command service</a>, using the <b>forcesave</b> value for the <em>c</em> parameter:
+            <li>Sending the request to the <a href="<%= Url.Action("command") %>">document command service</a>, using the <a href="<%= Url.Action("command/forcesave") %>">forcesave</a> value for the <em>c</em> parameter:
                 <pre>{
     "c": "forcesave",
     "key": "Khirz6zTPdfd7",

--- a/web/Views/Editors/Methods.aspx
+++ b/web/Views/Editors/Methods.aspx
@@ -32,7 +32,7 @@ var docEditor = new DocsAPI.DocEditor("placeholder", config);
             <li><a href="#setHistoryData">setHistoryData</a> - send the link to the document for viewing the version history.</li>
             <li><a href="#setMailMergeRecipients">setMailMergeRecipients</a> - insert recipient data for mail merge into the file.</li>
             <li><a href="#setRevisedFile">setRevisedFile</a> - select a document for comparing.</li>
-            <li><a href="#setSharingSettings">setSharingSettings</a> - update the <a href="<%= Url.Action("config/document/info") %>#sharingSettings">information</a> about the settings which allow to share the document with other users.</li>
+            <li><a href="#setSharingSettings">setSharingSettings</a> - update the <em>information</em> about the settings which allow to share the document with other users.</li>
             <li><a href="#setUsers">setUsers</a> - set a list of users to mention in the comments.</li>
             <li><a href="#showMessage">showMessage</a> - display tooltip with the message.</li>
         </ul>

--- a/web/Views/Editors/Rename.aspx
+++ b/web/Views/Editors/Rename.aspx
@@ -50,7 +50,7 @@ var docEditor = new DocsAPI.DocEditor("placeholder", {
         </li>
         <li>
             <p>
-                In order to update the name of the document for all collaborative editors, send the request to the <a href="<%= Url.Action("command") %>">document command service</a>, using the <a href="<%= Url.Action("command") %>#meta">meta</a> value for the <em>c</em> parameter:
+                In order to update the name of the document for all collaborative editors, send the request to the <a href="<%= Url.Action("command") %>">document command service</a>, using the <a href="<%= Url.Action("command/meta") %>">meta</a> value for the <em>c</em> parameter:
             </p>
             <pre>
 {
@@ -64,7 +64,7 @@ var docEditor = new DocsAPI.DocEditor("placeholder", {
         </li>
         <li>
             <p>
-                When the name of the document is changed via the <a href="<%= Url.Action("command") %>#meta">meta</a> command, the <a href="<%= Url.Action("config/events") %>#onMetaChange">onMetaChange</a> event must be called in the document editor of each user.
+                When the name of the document is changed via the <a href="<%= Url.Action("command/meta") %>">meta</a> command, the <a href="<%= Url.Action("config/events") %>#onMetaChange">onMetaChange</a> event must be called in the document editor of each user.
                 This event sends the name of the document in the <em>data.title</em> parameter.
             </p>
             <pre>

--- a/web/Views/Editors/Save.aspx
+++ b/web/Views/Editors/Save.aspx
@@ -132,7 +132,7 @@ new DocsAPI.DocEditor("placeholder", {
         The forcesave process can be initiated the following ways:
     </p>
     <ul>
-        <li>By the request to the <a href="<%= Url.Action("command") %>">document command service</a> with the <b>forcesave</b> value in the <em>c</em> parameter.
+        <li>By the request to the <a href="<%= Url.Action("command") %>">document command service</a> with the <a href="<%= Url.Action("command/forcesave") %>">forcesave</a> value in the <em>c</em> parameter.
             The <em>forcesavetype</em> parameter will have the <b>0</b> value when sending the request to the <b>callback handler</b>.</li>
         <li>Enable the <a href="<%= Url.Action("config/editor/customization") %>#forcesave">editorConfig.customization.forcesave</a> mode setting it to <b>true</b> in the editor initialization configuration.
             In this case each time the user clicks the <b>Save</b> button, the forcesave will be done, and the <em>forcesavetype</em> parameter will have the <b>1</b> value when sending the request to the <b>callback handler</b>.</li>


### PR DESCRIPTION
fixed links to the Command service page after its restructuring