### PR TITLE
Token in body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 
+- editors: the services.CoAuthoring.token.inbox.inBody and services.CoAuthoring.token.outbox.inBody parameters for enabling token in body are deprecated
 - editors: added the X-LOOL-WOPI-IsModifiedByUser, X-LOOL-WOPI-IsAutosave and X-LOOL-WOPI-IsExitSave request headers to the PutFile WOPI operation
 - editors: added the document.permissions.chat parameter
 - editors: added conversion from xlsb format

--- a/web/Views/Editors/Changelog.aspx
+++ b/web/Views/Editors/Changelog.aspx
@@ -18,6 +18,7 @@
     <p class="dscr">The list of changes of ONLYOFFICE Document Server API.</p>
     <h2 id="71" class="copy-link">Version 7.1</h2>
     <ul>
+        <li>The <em>services.CoAuthoring.token.inbox.inBody</em> and <em>services.CoAuthoring.token.outbox.inBody</em> parameters for enabling <a href="<%= Url.Action("signature/body") %>">token in body</a> are deprecated.
         <li>Added the <em>X-LOOL-WOPI-IsModifiedByUser</em>, <em>X-LOOL-WOPI-IsAutosave</em> and <em>X-LOOL-WOPI-IsExitSave</em> request headers to the <a href="<%= Url.Action("wopi/restapi/putfile") %>">PutFile</a> WOPI operation to distinguish between the type of document saving.</li>
         <li>The <a href="<%= Url.Action("config/editor/customization") %>#chat">editorConfig.customization.chat</a> parameter is deprecated, please use the <a href="<%= Url.Action("config/document/permissions") %>#chat">document.permissions.chat</a> parameter instead.</li>
         <li>Added conversion from <a href="<%= Url.Action("conversionapi") %>#spreadsheet-matrix">xlsb</a> format.</li>

--- a/web/Views/Editors/Changelog.aspx
+++ b/web/Views/Editors/Changelog.aspx
@@ -18,7 +18,7 @@
     <p class="dscr">The list of changes of ONLYOFFICE Document Server API.</p>
     <h2 id="71" class="copy-link">Version 7.1</h2>
     <ul>
-        <li>The <em>services.CoAuthoring.token.inbox.inBody</em> and <em>services.CoAuthoring.token.outbox.inBody</em> parameters for enabling <a href="<%= Url.Action("signature/body") %>">token in body</a> are deprecated.
+        <li>The <em>services.CoAuthoring.token.inbox.inBody</em> and <em>services.CoAuthoring.token.outbox.inBody</em> parameters for enabling <a href="<%= Url.Action("signature/body") %>">token in body</a> are deprecated.</li>
         <li>Added the <em>X-LOOL-WOPI-IsModifiedByUser</em>, <em>X-LOOL-WOPI-IsAutosave</em> and <em>X-LOOL-WOPI-IsExitSave</em> request headers to the <a href="<%= Url.Action("wopi/restapi/putfile") %>">PutFile</a> WOPI operation to distinguish between the type of document saving.</li>
         <li>The <a href="<%= Url.Action("config/editor/customization") %>#chat">editorConfig.customization.chat</a> parameter is deprecated, please use the <a href="<%= Url.Action("config/document/permissions") %>#chat">document.permissions.chat</a> parameter instead.</li>
         <li>Added conversion from <a href="<%= Url.Action("conversionapi") %>#spreadsheet-matrix">xlsb</a> format.</li>

--- a/web/Views/Editors/Navigation.ascx
+++ b/web/Views/Editors/Navigation.ascx
@@ -267,13 +267,13 @@
                 <a href="<%= Url.Action("signature/browser") %>">Browser</a>
             </li>
             <li>
-                <a href="<%= Url.Action("signature/request") %>">Request</a>
+                <a href="<%= Url.Action("signature/body") %>">Request</a>
                 <ul>
                     <li>
-                        <a href="<%= Url.Action("signature/request") %>">Token in header</a>
+                        <a href="<%= Url.Action("signature/body") %>">Token in body</a>
                     </li>
                     <li>
-                        <a href="<%= Url.Action("signature/body") %>">Token in body</a>
+                        <a href="<%= Url.Action("signature/request") %>">Token in header</a>
                     </li>
                 </ul>
             </li>

--- a/web/Views/Editors/Signature/Body.ascx
+++ b/web/Views/Editors/Signature/Body.ascx
@@ -15,7 +15,9 @@
     To enable it set the <em>services.CoAuthoring.token.inbox.inBody</em> and <em>services.CoAuthoring.token.outbox.inBody</em> in configuration file to <b>true</b>.
 </p>
 <p>
-    Starting from version 7.1, these parameters are deprecated. Now the incoming requests use the token in body if it exists. Otherwise, the header token is taken.
+    Starting from version 7.1, these parameters are deprecated.
+    Now the incoming requests use the token in body if it exists.
+    Otherwise, the header token is taken.
     To specify what is used next to validate the data, <b>tokenRequiredParams</b> must be added to the <em>local.json</em> configuration file. If it is <b>true</b>, only the token data is used.
     Otherwise, the opened request part is merged with the token data.
 </p>
@@ -48,13 +50,19 @@
     <tbody>
         <tr class="tablerow">
             <td>services.CoAuthoring.token.inbox.inBody</td>
-            <td>Specifies the enabling the token validation in the request body to the <b>document command service</b>, <b>document conversion service</b> and <b>document builder service</b>. Deprecated since version 7.1.</td>
+            <td>
+                Specifies the enabling the token validation in the request body to the <b>document command service</b>, <b>document conversion service</b> and <b>document builder service</b>.
+                Deprecated since version 7.1.
+            </td>
             <td>boolean</td>
             <td>false</td>
         </tr>
         <tr class="tablerow">
             <td>services.CoAuthoring.token.outbox.inBody</td>
-            <td>Specifies the enabling the token generation for the request body by <b>document editing service</b> to <b>document storage service</b>. Deprecated since version 7.1.</td>
+            <td>
+                Specifies the enabling the token generation for the request body by <b>document editing service</b> to <b>document storage service</b>.
+                Deprecated since version 7.1.
+            </td>
             <td>boolean</td>
             <td>false</td>
         </tr>

--- a/web/Views/Editors/Signature/Body.ascx
+++ b/web/Views/Editors/Signature/Body.ascx
@@ -18,7 +18,7 @@
     Starting from version 7.1, these parameters are deprecated.
     Now the incoming requests use the token in body if it exists.
     Otherwise, the header token is taken.
-    To specify what is used next to validate the data, <b>tokenRequiredParams</b> must be added to the <em>local.json</em> configuration file. If it is <b>true</b>, only the token data is used.
+    To specify what is used next to validate the data, <em>services.CoAuthoring.server.tokenRequiredParams</em> must be added to the <em>local.json</em> configuration file. If it is <b>true</b>, only the token data is used.
     Otherwise, the opened request part is merged with the token data.
 </p>
 <p>

--- a/web/Views/Editors/Signature/Body.ascx
+++ b/web/Views/Editors/Signature/Body.ascx
@@ -11,8 +11,17 @@
 </p>
 
 <p>
-    Starting with version 5.2 it is possible to use the token in body parameters with <b>Document Server</b>.
+    Starting from version 5.2, it is possible to use the token in body parameters with <b>Document Server</b>.
     To enable it set the <em>services.CoAuthoring.token.inbox.inBody</em> and <em>services.CoAuthoring.token.outbox.inBody</em> in configuration file to <b>true</b>.
+</p>
+<p>
+    Starting from version 7.1, these parameters are deprecated. Now the incoming requests use the token in body if it exists. Otherwise, the header token is taken.
+    To specify what is used next to validate the data, <b>tokenRequiredParams</b> must be added to the <em>local.json</em> configuration file. If it is <b>true</b>, only the token data is used.
+    Otherwise, the opened request part is merged with the token data.
+</p>
+<p>
+    The outgoing requests use both the token in body and token in header. They can be different.
+    For example, the information about version history can be removed from the header token because of the size limit of the token in header.
 </p>
 
 <div class="note">
@@ -39,39 +48,19 @@
     <tbody>
         <tr class="tablerow">
             <td>services.CoAuthoring.token.inbox.inBody</td>
-            <td>Specifies the enabling the token validation in the request body to the <b>document command service</b>, <b>document conversion service</b> and <b>document builder service</b>.</td>
+            <td>Specifies the enabling the token validation in the request body to the <b>document command service</b>, <b>document conversion service</b> and <b>document builder service</b>. Deprecated since version 7.1.</td>
             <td>boolean</td>
             <td>false</td>
         </tr>
         <tr class="tablerow">
             <td>services.CoAuthoring.token.outbox.inBody</td>
-            <td>Specifies the enabling the token generation for the request body by <b>document editing service</b> to <b>document storage service</b>.</td>
+            <td>Specifies the enabling the token generation for the request body by <b>document editing service</b> to <b>document storage service</b>. Deprecated since version 7.1.</td>
             <td>boolean</td>
             <td>false</td>
         </tr>
     </tbody>
 </table>
 <div class="mobile-content"></div>
-
-
-<div class="header-gray">Sample local.json configuration</div>
-<pre>
-{
-    "services": {
-        "CoAuthoring": {
-            "token": {
-                "inbox": {
-                    "inBody": true,
-                },
-                "outbox": {
-                    "inBody": true
-                }
-            }
-        }
-    }
-}
-</pre>
-
 
 <p>The <em>payload</em> for the JSON Web Token contains the request body parameters.</p>
 


### PR DESCRIPTION
the services.CoAuthoring.token.inbox.inBody and services.CoAuthoring.token.outbox.inBody parameters for enabling token in body are deprecated