### PR TITLE
Hotfix/3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 3.0.1
+- docbuilder: fix method links
+
 ## 3.0.0
 - editors: added the WOPI Conversion API
 - editors: added the UserCanNotWriteRelative property to the CheckFileInfo WOPI operation

--- a/web/Views/DocBuilder/sectionpartial.aspx
+++ b/web/Views/DocBuilder/sectionpartial.aspx
@@ -80,7 +80,7 @@
         <tbody>
             <% foreach (var method in section.Methods) { %>
                 <tr class="tablerow">
-                    <td><a href="<%= Url.Action(string.Format("{0}/{1}/{2}", section.Path, section.Name.ToLower(), method.Key.ToLower())) %>"><%= method.Key %></a></td>
+                    <td><a href="<%= method.Value.Path %>"><%= method.Key %></a></td>
                     <td><%= method.Value.Description %></td>
                 </tr>
             <% } %>
@@ -100,7 +100,7 @@
         <tbody>
             <% foreach(var ev in section.Events) { %>
                 <tr class="tablerow">
-                    <td><a href="<%= Url.Action(string.Format("{0}/{1}/event-{2}", section.Path, section.Name.ToLower(), ev.Key.ToLower())) %>"><%= ev.Key %></a></td>
+                    <td><a href="<%= ev.Value.Path %>"><%= ev.Key %></a></td>
                     <td><%= ev.Value.Description %></td>
                 </tr>
             <% } %>


### PR DESCRIPTION
- docbuilder: fix method links