### PR TITLE
docs_api_config WOPI parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ##
+- editors: added the docs_api_config parameter to the form element of the WOPI host page
 - editors: added the pdf field to the conversion request
 - editors: added the events.onSubmit event
 - editors: the docxf format is deprecated, please use the pdf format to create and edit forms

--- a/web/Views/Editors/Changelog.aspx
+++ b/web/Views/Editors/Changelog.aspx
@@ -18,6 +18,7 @@
     <p class="dscr">The list of changes of ONLYOFFICE Docs API.</p>
     <h2 id="81" class="copy-link">Version 8.1</h2>
     <ul>
+        <li>Added the <a href="<%= Url.Action("wopi/hostpage") %>#docs_api_config">docs_api_config</a> parameter to the <em>form</em> element of the WOPI host page.</li>
         <li>Added the <a href="<%= Url.Action("conversionapi") %>#pdf">pdf</a> field to the conversion request.</li>
         <li>Added the <a href="<%= Url.Action("config/events") %>#onSubmit">events.onSubmit</a> event.</li>
         <li>The <em>docxf</em> format is deprecated, please use the <em>pdf</em> format to create and edit forms.</li>

--- a/web/Views/Editors/WOPI/HostPage.ascx
+++ b/web/Views/Editors/WOPI/HostPage.ascx
@@ -57,6 +57,7 @@
     &lt;form id="office_form" name="office_form" target="office_frame" action="&lt;%= actionUrl %&gt;" method="post"&gt;
         &lt;input name="access_token" value="&lt;%= token %&gt;" type="hidden" /&gt;
         &lt;input name="access_token_ttl" value="&lt;%= tokenTtl %&gt;" type="hidden" /&gt;
+        &lt;input name="docs_api_config" value="{&quot;editorConfig&quot;:{&quot;customization&quot;:{&quot;forcesave&quot;:true}}}" type="hidden" /&gt;
     &lt;/form&gt;
 
     &lt;span id="frameholder"&gt;&lt;/span&gt;
@@ -108,6 +109,13 @@
                 <td>The time when an access token expires, represented as the number of milliseconds since January 1, 1970 UTC.
                 It is recommended to set this parameter to 10 hours.</td>
                 <td>integer</td>
+            </tr>
+            <tr>
+                <td id="docs_api_config" class="copy-link">docs_api_config</td>
+                <td>The <a href="<%= Url.Action("config") %>">config</a> parameters for opening the editor via Docs API
+                that are not supported by the WOPI protocol. For example, to enable the <a href="<%= Url.Action("save") %>#forcesave">forcesaving</a> functionality
+                by clicking the <b>Save</b> button, the <a href="<%= Url.Action("config/editor/customization") %>#forcesave">editorConfig.customization.forcesave</a> parameter must be passed in this object.</td>
+                <td>string</td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
editors: added the docs_api_config parameter to the form element of the WOPI host page